### PR TITLE
Fix for latest version of SDCC

### DIFF
--- a/libsrc/Makefile
+++ b/libsrc/Makefile
@@ -18,8 +18,7 @@ CRT = c64_prg_crt0.rel c64_cart_crt0.rel
 OBJECTS = putchar.rel kbhit.rel cgetc.rel cputc.rel cputs.rel gotoxy.rel bordercolor.rel clrscr.rel
 
 all: $(CRT) $(OBJECTS)
-	$(SDCCDIR)/sdar -rcSD c64.lib $(OBJECTS)
-	$(SDCCDIR)/sdar s c64.lib
+	$(SDCCDIR)sdar rcSDs c64.lib $(OBJECTS)
 	mkdir -p ../lib
 	cp c64.lib ../lib
 	cp c64_cart_crt0.rel ../lib


### PR DESCRIPTION
In recent versions of SDCC, if `sdar` is used more than once on the same library, it seems to create a lib file that cannot be used properly by the linker. This may be caused by https://sourceforge.net/p/sdcc/bugs/3569/.
